### PR TITLE
Fix types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 declare module 'replace-in-file' {
   function replaceInFile(config: ReplaceInFileConfig): Promise<ReplaceResult[]>;
   function replaceInFile(config: ReplaceInFileConfig, cb: (error: Error, results: ReplaceResult[]) => void): void;
-  export default replaceInFile;
+  export = replaceInFile;
 
   namespace replaceInFile {
     export function sync(config: ReplaceInFileConfig): ReplaceResult[];
@@ -17,6 +17,7 @@ declare module 'replace-in-file' {
     disableGlobs?: boolean,
     encoding?: string,
     dry?:boolean
+    ignore?: string | string[]
   }
 
   export interface ReplaceResult {


### PR DESCRIPTION
- adding ignore field
- change it back to es5 export, since js side doesn't really export `default`

It's meant to be used like

`import replace = require('replace-in-file')`